### PR TITLE
fix: Docs for specifying custom binary path

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,7 @@ It can also be configured like this:
 {
   "lsp": {
     "psalm": {
-      "settings": {
-        "binary": "vendor/bin/psalm"
-      }
+       "binary": {"path": "vendor/bin/psalm" }
     }
   }
 }


### PR DESCRIPTION
As per code in 
https://github.com/sebcode/psalm-zed/blob/c2310ad215efd86d6f1cd972efa3021582f7b51b/src/psalm.rs#L62-L65
, binary is available at the top level and requires `path`